### PR TITLE
Server was not listening on the correct port

### DIFF
--- a/src/IDE/Metainfo/Collector.hs
+++ b/src/IDE/Metainfo/Collector.hs
@@ -196,14 +196,13 @@ main =  withSocketsDo $ catch inner handler
                             else
                                 case servers of
                                     (Nothing:_)  -> do
-                                        running <- serveOne Nothing (server (PortNum (fromIntegral
-                                            (serverPort prefs))) newPrefs connRef threadId localServerAddr)
+                                        running <- serveOne Nothing (server (fromIntegral
+                                            (serverPort prefs)) newPrefs connRef threadId localServerAddr)
                                         waitFor running
                                         return ()
                                     (Just ps:_)  -> do
                                         let port = read $ T.unpack ps
-                                        running <- serveOne Nothing (server (PortNum
-                                            (fromIntegral port)) newPrefs connRef threadId localServerAddr)
+                                        running <- serveOne Nothing (server (fromIntegral port) newPrefs connRef threadId localServerAddr)
                                         waitFor running
                                         return ()
                                     _ -> return ()


### PR DESCRIPTION
Removing the deprecated PortNum constructor in leksah (https://github.com/leksah/leksah/commit/97db94ab8e4a7c0e7847112aa7955f23e6c36919) caused a bug: the server could not be found. Appearantly, the communication between leksah and leksah-server before never happened over the intended port (11111) but on 26411 (at least on Ubuntu 15.05). This was caused by the PortNum constructor from Network.Socket converting the provded Word16 in some way.