### PR TITLE
Ignore .ghci file for cabal repl

### DIFF
--- a/src/IDE/Utils/Tool.hs
+++ b/src/IDE/Utils/Tool.hs
@@ -497,7 +497,7 @@ newGhci' flags startupOutputHandler = do
     tool <- newToolState
     writeChan (toolCommands tool) $
         ToolCommand (":set prompt " <> ghciPrompt) "" startupOutputHandler
-    runInteractiveTool tool ghciCommandLineReader "ghci" flags Nothing
+    runInteractiveTool tool ghciCommandLineReader "ghci" ("--ghc-options=-ignore-dot-ghci" : flags) Nothing
     return tool
 
 newGhci :: FilePath -> Maybe Text -> [Text] -> C.Sink ToolOutput IO () -> IO ToolState
@@ -506,7 +506,7 @@ newGhci dir mbExe interactiveFlags startupOutputHandler = do
         writeChan (toolCommands tool) $
             ToolCommand (":set " <> T.unwords interactiveFlags <> "\n:set prompt " <> ghciPrompt) "" startupOutputHandler
         runInteractiveTool tool ghciCommandLineReader "cabal"
-            ("repl" : maybeToList mbExe) (Just dir)
+            ("repl" : "--ghc-options=-ignore-dot-ghci" : maybeToList mbExe) (Just dir)
         return tool
 
 executeCommand :: ToolState -> Text -> Text -> C.Sink ToolOutput IO () -> IO ()


### PR DESCRIPTION
I think this should solve issues with custom prompts and other stuff that might be in a .ghci file (leksah/leksah#159)