### PR TITLE
Multiple mains

### DIFF
--- a/src/IDE/Core/CTypes.hs
+++ b/src/IDE/Core/CTypes.hs
@@ -216,10 +216,18 @@ instance Show (Present ModuleDescr) where
     show (Present md)   =   (show . mdModuleId) md
 
 instance Eq ModuleDescr where
-    (== ) a b            =   mdModuleId a == mdModuleId b
+    (== ) a b            =   let
+        idEq = mdModuleId a == mdModuleId b
+        in if idEq && ["Main"]  == components (modu (mdModuleId a))
+                then mdMbSourcePath a == mdMbSourcePath b
+                else idEq
 
 instance Ord ModuleDescr where
-    (<=) a b             =   mdModuleId a <=  mdModuleId b
+    (<=) a b             =   let
+        idEq = mdModuleId a == mdModuleId b
+        in if idEq && ["Main"]  == components (modu (mdModuleId a))
+                then mdMbSourcePath a <= mdMbSourcePath b
+                else mdModuleId a <=  mdModuleId b
 
 data Descr =  Real RealDescr | Reexported ReexportedDescr
         deriving (Show,Read,Typeable,Eq,Ord)

--- a/src/IDE/Core/CTypes.hs
+++ b/src/IDE/Core/CTypes.hs
@@ -218,6 +218,7 @@ instance Show (Present ModuleDescr) where
 instance Eq ModuleDescr where
     (== ) a b            =   let
         idEq = mdModuleId a == mdModuleId b
+        -- Main modules are only the same if they use the same file
         in if idEq && ["Main"]  == components (modu (mdModuleId a))
                 then mdMbSourcePath a == mdMbSourcePath b
                 else idEq
@@ -225,6 +226,7 @@ instance Eq ModuleDescr where
 instance Ord ModuleDescr where
     (<=) a b             =   let
         idEq = mdModuleId a == mdModuleId b
+        -- use source files for main modules
         in if idEq && ["Main"]  == components (modu (mdModuleId a))
                 then mdMbSourcePath a <= mdMbSourcePath b
                 else mdModuleId a <=  mdModuleId b

--- a/src/IDE/Metainfo/WorkspaceCollector.hs
+++ b/src/IDE/Metainfo/WorkspaceCollector.hs
@@ -157,7 +157,8 @@ collectModule collectorPackagePath writeAscii pid opts (modId,sourcePath) = do
                             else return ()
             else errorM "leksah-server" ("source file not found " ++ sourcePath)
     where
-        collectorModulePath = collectorPackagePath </> T.unpack modId <.> leksahMetadataWorkspaceFileExtension
+        mdString = T.unpack modId
+        collectorModulePath = collectorPackagePath </> (moduleCollectorFileName mdString sourcePath) <.> leksahMetadataWorkspaceFileExtension
         mbModuleName = simpleParse $ T.unpack modId
 
 

--- a/src/IDE/Utils/FileUtils.hs
+++ b/src/IDE/Utils/FileUtils.hs
@@ -31,6 +31,8 @@ module IDE.Utils.FileUtils (
 ,   getSysLibDir
 ,   moduleNameFromFilePath
 ,   moduleNameFromFilePath'
+,   moduleCollectorFileName
+,   moduleCollectorFileName'
 ,   findKnownPackages
 ,   isSubPath
 ,   findSourceFile
@@ -51,7 +53,7 @@ import Control.Applicative
 import Prelude hiding (readFile)
 import System.FilePath
        (splitFileName, dropExtension, takeExtension,
-        combine, addExtension, (</>), normalise, splitPath, takeFileName)
+        combine, addExtension, (</>), normalise, splitPath, takeFileName,takeDirectory)
 import Distribution.ModuleName (toFilePath, ModuleName)
 import Control.Monad (when, foldM, filterM)
 import Data.Maybe (mapMaybe, catMaybes)
@@ -267,6 +269,26 @@ moduleNameFromFilePath' fp str = do
             case parseRes of
                 Left _ -> return Nothing
                 Right str'' -> return (Just str'')
+
+-- | Get the file name to use for the module collector results
+-- we want to store the file name for Main module since there can be several in one package
+moduleCollectorFileName
+    :: String -- ^ The module name as a String
+    -> FilePath -- ^ The source file for the module
+    -> String -- ^ The name to use for the collector file (without extension)
+moduleCollectorFileName mdString sourcePath =
+    if mdString == "Main"
+          then mdString ++ "_" ++ "_" ++ takeFileName (takeDirectory sourcePath) ++ dropExtension (takeFileName sourcePath)
+          else mdString
+
+-- | Get the file name to use for the module collector results
+-- we want to store the file name for Main module since there can be several in one package
+moduleCollectorFileName'
+    :: String -- ^ The module name as a String
+    -> Maybe FilePath -- ^ The source file for the module if we have it
+    -> String -- ^ The name to use for the collector file (without extension)
+moduleCollectorFileName' mdString (Just sourcePath) = moduleCollectorFileName mdString sourcePath
+moduleCollectorFileName' mdString _ = mdString
 
 lexer :: P.TokenParser st
 lexer = haskell


### PR DESCRIPTION
This is the leksah-server part of handling multiple executables in a project (to fix https://github.com/leksah/leksah/issues/222). The most important change is that the workspace collector uses the file name as well as the module name to store collection information for Main modules.